### PR TITLE
Remove version 1.4;  add versions 1.6 and 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,18 @@
 language: c
 
 env:
-    - SMVERSION=1.4
     - SMVERSION=1.5
     - SMVERSION=1.6
-    - SMVERSION=2.0
+    - SMVERSION=1.7
+
+matrix:
+    fast_finish: true
+    allow_failures:
+        - env: SMVERSION=1.7
+    
 before_install:
     - sudo apt-get update
+    - sudo apt-get install gcc-multilib
     - sudo apt-get install lynx
 
 before_script:


### PR DESCRIPTION
Sourcemod 1.4 is no longer actively used and 1.6 is going to be released soon. I also added version 1.7 but under an `allow_failures` matrix as it is not currently fully stable.
