### PR TITLE
Move to Version 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: c
 
 env:
-    - SMVERSION=1.5
     - SMVERSION=1.6
     - SMVERSION=1.7
+    - SMVERSION=1.8
 
 matrix:
     fast_finish: true
     allow_failures:
-        - env: SMVERSION=1.7
+        - env: SMVERSION=1.8
     
 before_install:
     - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
     - sudo apt-get update
     - sudo apt-get install gcc-multilib
     - sudo apt-get install lynx
+    - sudo apt-get install lib32stdc++6
 
 before_script:
     - SMPATTERN="http:.*sourcemod-.*-linux.*"


### PR DESCRIPTION
Remove version 1.5 build and make version 1.7 a primary build version.  Also add a version 1.8 build that allows failures.  

Also install lib32stdc++6 as this is now required from new versions of SourceMod.
